### PR TITLE
removed unneeded allocations when calling `any` and `all` functions with generator

### DIFF
--- a/src/Execute/Execute.jl
+++ b/src/Execute/Execute.jl
@@ -47,7 +47,7 @@ const qubit_map = Dict('0' => _0, '1' => _1)
 #const _00 = kron(_0, _0)
 
 function str2state(s)
-    @assert all([c in ('0', '1') for c in s]) "Only 0 and 1 are allowed."
+    @assert all(c in ('0', '1') for c in s) "Only 0 and 1 are allowed."
 
     # Reverse the bit order
     s = reverse(s)

--- a/src/QCircuits/Graph.jl
+++ b/src/QCircuits/Graph.jl
@@ -58,7 +58,7 @@ const qubitToLine(q) = q + 1
 "Add gate to circuit"
 function add!(g::DirectedGraph{IndexT}, gate::QuantumGate) where IndexT<:Integer
     qubits = getqubitsids(gate)
-    @assert all([q < g.qubits for q in qubits]) "Qubits in gate $gate is out of DAG qubits range $(g.qubits)."
+    @assert all(q < g.qubits for q in qubits) "Qubits in gate $gate is out of DAG qubits range $(g.qubits)."
 
     @assert length(g.vertices) == length(g.in_edges) "Inexpected inconsistency between length of vertices and in edges"
     @assert length(g.vertices) == length(g.out_edges) "Inexpected inconsistency between length of vertices and out edges"

--- a/src/QML/Optimization.jl
+++ b/src/QML/Optimization.jl
@@ -254,7 +254,7 @@ function gradientDescent(of::OptimizationFunction, x; α=0.001, maxItr=nothing, 
         # Check if we have solution
         # check val if the zero is expected
         # @show all(abs.(dval) .< ϵ), any([isnan(p) for p in x]), (isExpectedZero && val < ϵ)
-        if all(abs.(dval) .< ϵ) || any([isnan(p) for p in x]) || (isExpectedZero && val < ϵ)
+        if all(abs.(dval) .< ϵ) || any(isnan(p) for p in x) || (isExpectedZero && val < ϵ)
             process = false
         end
         if diffx < 2*ϵ && itr > 2000


### PR DESCRIPTION
Fixes #14 in the sense that it removes unneeded allocations when calling `any` and `all` functions with generator, but if there are still other kind of unneded allocations, let me know to check as well.