### PR TITLE
Fixes #9

### DIFF
--- a/src/QCircuits/Qiskit.jl
+++ b/src/QCircuits/Qiskit.jl
@@ -115,7 +115,7 @@ function draw(qc::QiskitCircuit)
 end
 
 "Function return the register"
-getQRegister(qc::QiskitCircuit, name::String) = qc.qRegs[name]
+getQRegister(qc::QiskitCircuit, name::AbstractString) = qc.qRegs[name]
 
 
 "Add quantum gate to Qiskit circuit"


### PR DESCRIPTION
As suggested by @jlapeyre 
Changed name to ```AbstractString``` type.
Now, ```SubString``` will also be accepted.