### PR TITLE
Improve performance in unitary_error

### DIFF
--- a/src/QCircuits/Circuit.jl
+++ b/src/QCircuits/Circuit.jl
@@ -225,8 +225,8 @@ function add!(qc::QCircuit, gate::Type{<:QuantumGate}, qubit::Integer, θ)
 end
 
 function add!(qc::QCircuit, gate::Type{<:QuantumGate}, qubits::Vector, θ)
-    for i in eachindex(qubits)
-        add!(qc, gate, qubits[i], θ)
+    for qubit in qubits
+        add!(qc, gate, qubit, θ)
     end
 end
 
@@ -244,7 +244,7 @@ function add!(qc::QCircuit, gate::Type{<:QuantumGate}, qubit::Integer, θ, ϕ, �
 
     nothing
 end
-function add!(qc::QCircuit, gate::Type{<:QuantumGate}, qubits::AbstractVector, θ, ϕ, λ) 
+function add!(qc::QCircuit, gate::Type{<:QuantumGate}, qubits::AbstractVector, θ, ϕ, λ)
     for qubit in qubits
         add!(qc, gate, qubit, ParameterT(θ), ParameterT(ϕ), ParameterT(λ))
     end

--- a/src/QCircuits/Math.jl
+++ b/src/QCircuits/Math.jl
@@ -18,8 +18,12 @@ export unitary_error, matrix_norm, eye, observe_unitary_error,
        min_observe_unitary_error
 
 "Calculate the unitary matrix error"
-function unitary_error(exp_unit, mat_unit, exp_scale=1.0, mat_scale=1.0)
-    sum(((a,b),) -> abs2(a*exp_scale - b*mat_scale), zip(exp_unit, mat_unit))
+unitary_error(exp_unit, mat_unit) = _unitary_error(exp_unit, mat_unit)
+function unitary_error(exp_unit, mat_unit, exp_scale, mat_scale)
+    return _unitary_error(exp_unit, mat_unit, x -> x * exp_scale, x -> x * mat_scale)
+end
+function _unitary_error(exp_unit, mat_unit, fa=identity, fb=identity)
+    return sum(((a, b),) -> abs2(fa(a) - fb(b)), zip(exp_unit, mat_unit))
 end
 
 "Calculate the observe unitary matrix error, the error which we can obserwe

--- a/src/QCircuits/Math.jl
+++ b/src/QCircuits/Math.jl
@@ -18,25 +18,24 @@ export unitary_error, matrix_norm, eye, observe_unitary_error,
        min_observe_unitary_error
 
 "Calculate the unitary matrix error"
-function unitary_error(exp_unit, mat_unit)
-    sum(((a,b),) -> abs2(a - b), zip(exp_unit, mat_unit))
+function unitary_error(exp_unit, mat_unit, exp_scale=1.0, mat_scale=1.0)
+    sum(((a,b),) -> abs2(a*exp_scale - b*mat_scale), zip(exp_unit, mat_unit))
 end
 
 "Calculate the observe unitary matrix error, the error which we can obserwe
 from quantum state"
 function observe_unitary_error(exp_unit, mat_unit, index=1)
     # Remove phase
-    exp_unit = exp_unit[:] .* cis(-angle(exp_unit[index]))
-    mat_unit = mat_unit[:] .* cis(-angle(mat_unit[index]))
+    exp_scale = cis(-angle(exp_unit[index]))
+    mat_scale = cis(-angle(mat_unit[index]))
 
-    return unitary_error(exp_unit, mat_unit)
+    return unitary_error(exp_unit, mat_unit, exp_scale, mat_scale)
 end
 
 "Calculate the minimum observe unitary matrix error."
 function min_observe_unitary_error(exp_unit, mat_unit)
     l = length(exp_unit)
-    ret = [observe_unitary_error(exp_unit, mat_unit, i) for i in 1:l]
-    return minimum(ret)
+    return minimum(i -> observe_unitary_error(exp_unit, mat_unit, i), 1:l)
 end
 
 "Calculate the matrix norm"


### PR DESCRIPTION
Fix the issue https://github.com/Adgnitio/QuantumCircuits.jl/issues/12

In observe_unitary_error I did in a slightly different way to avoid copying the code from unitary_error function. 
But all other hints should be included. @jlapeyre  Could you look?